### PR TITLE
expose posts endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This Strapi dashboard keeps custom behaviour inside `src/plugins/ceramic-feed`, which exposes server hooks and CLI utilities. Core configuration lives in `config/` (database, plugins, middleware) and reads from environment variables. Static assets and the Strapi admin build output go in `public/`. The `database/migrations` folder is reserved for SQL migrations; drop migration scripts there to keep environments in sync.
+
+## Build, Test, and Development Commands
+Use Yarn 3.6.1 with Node ≥16. Frequent tasks:
+- `yarn develop` runs Strapi in watch mode with a SQLite database by default.
+- `yarn start` serves the compiled app in production-like mode.
+- `yarn build` rebuilds the admin panel assets.
+- `yarn lint` checks JavaScript in `config/` and `src/plugins/ceramic-feed/`.
+- `yarn lint:fix` applies auto-fixes from ESLint.
+- `yarn generate:ceramic:seed` seeds demo feed data; run it after bootstrapping a new database.
+- `yarn client:settings` refreshes Orbis client configuration used by the plugin.
+Always create `.env` files rather than editing `config/*.js` directly.
+
+## Coding Style & Naming Conventions
+ESLint (`.eslintrc`) enforces 2-space indentation, single quotes, required semicolons, and Unix line endings. Keep module exports CommonJS-style to match Strapi expectations. Prefer `camelCase` for functions/variables, kebab-case for file names, and avoid default exports inside the plugin. Run lint before submitting.
+
+## Testing Guidelines
+An automated test harness has not been wired up. For now, smoke-test changes by running `yarn develop`, exercising the Ceramic Feed plugin flows, and invoking CLI utilities. When adding automated coverage, follow Jest conventions (`*.test.js` files alongside the code) and add a `yarn test` script so CI can trigger it. Document manual test steps in pull requests until automated coverage exists.
+
+## Commit & Pull Request Guidelines
+Follow the existing Conventional Commit style (`fix:`, `chore:`, `add:`). Scope commits to one concern and mention affected plugin modules. Pull requests should include a brief narrative, screenshots for admin UI tweaks, environment notes (e.g., which storage provider), and a checklist showing lint/tests run. Link Jira or GitHub issues and flag any required secrets.
+
+## Configuration & Security Notes
+Sensitive credentials for AWS S3 uploads and Ceramic access come from environment variables (`AWS_*`, `CERAMIC_*`, `WEB3STORAGE_GATEWAY`). Public feed access is gated by `CERAMIC_FEED_ALLOWED_ORIGINS`; keep the list tight and mirror it in any Cloudflare rules. Never commit secrets or `.env` files. Rotate or revoke credentials if a partner key leaks and update `config/plugins.js` to point at the new values.

--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -1,6 +1,15 @@
 module.exports = ({ env }) => {
   const provider = env('UPLOAD_PROVIDER', 'local')
   const limit = env.int('UPLOAD_LIMIT', 200)
+  const allowedOrigins = env.array('CERAMIC_FEED_ALLOWED_ORIGINS', [
+    'http://localhost:1337',
+    'http://127.0.0.1:1337',
+    'http://0.0.0.0:1337',
+    'http://localhost:3000',
+    'https://localhost:3000',
+    'https://localhost:1337',
+    'https://127.0.0.1:1337',
+  ])
   let strapiSecurity = 'strapi::security'
 
   const strapiBody = {
@@ -43,7 +52,22 @@ module.exports = ({ env }) => {
   return [
     'strapi::errors',
     strapiSecurity,
-    'strapi::cors',
+    {
+      name: 'strapi::cors',
+      config: {
+        origin: allowedOrigins,
+        headers: [
+          'Content-Type',
+          'Authorization',
+          'Origin',
+          'Accept',
+          'User-Agent',
+          'Referer',
+        ],
+        methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+        keepHeaderOnError: true,
+      },
+    },
     'strapi::poweredBy',
     'strapi::logger',
     'strapi::query',

--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -1,15 +1,14 @@
+const {
+  DEFAULT_ALLOWED_ORIGINS
+} = require('../src/plugins/ceramic-feed/server/config/defaults')
+
 module.exports = ({ env }) => {
   const provider = env('UPLOAD_PROVIDER', 'local')
   const limit = env.int('UPLOAD_LIMIT', 200)
-  const allowedOrigins = env.array('CERAMIC_FEED_ALLOWED_ORIGINS', [
-    'http://localhost:1337',
-    'http://127.0.0.1:1337',
-    'http://0.0.0.0:1337',
-    'http://localhost:3000',
-    'https://localhost:3000',
-    'https://localhost:1337',
-    'https://127.0.0.1:1337'
-  ])
+  const allowedOrigins = env.array(
+    'CERAMIC_FEED_ALLOWED_ORIGINS',
+    DEFAULT_ALLOWED_ORIGINS
+  )
   let strapiSecurity = 'strapi::security'
 
   const strapiBody = {

--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -8,23 +8,23 @@ module.exports = ({ env }) => {
     'http://localhost:3000',
     'https://localhost:3000',
     'https://localhost:1337',
-    'https://127.0.0.1:1337',
+    'https://127.0.0.1:1337'
   ])
   let strapiSecurity = 'strapi::security'
 
   const strapiBody = {
-    name: "strapi::body",
+    name: 'strapi::body',
     config: {
-      formLimit: "256mb", // modify form body
-      jsonLimit: "256mb", // modify JSON body
-      textLimit: "256mb", // modify text body
+      formLimit: '256mb', // modify form body
+      jsonLimit: '256mb', // modify JSON body
+      textLimit: '256mb', // modify text body
       formidable: {
-        maxFileSize: limit * 1024, // multipart data, modify here limit of uploaded file size (in kB)
-      },
-    },
+        maxFileSize: limit * 1024 // multipart data, modify here limit of uploaded file size (in kB)
+      }
+    }
   }
 
-  if ('aws-s3' === provider)  {
+  if ('aws-s3' === provider) {
     const bucket = env('AWS_BUCKET')
     const region = env('AWS_REGION')
 
@@ -42,10 +42,10 @@ module.exports = ({ env }) => {
             'connect-src': ["'self'", 'https:'],
             'img-src': ["'self'", 'data:', 'blob:', ...allowedSource],
             'media-src': ["'self'", 'data:', 'blob:', ...allowedSource],
-            upgradeInsecureRequests: null,
-          },
-        },
-      },
+            upgradeInsecureRequests: null
+          }
+        }
+      }
     }
   }
 
@@ -62,11 +62,11 @@ module.exports = ({ env }) => {
           'Origin',
           'Accept',
           'User-Agent',
-          'Referer',
+          'Referer'
         ],
         methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
-        keepHeaderOnError: true,
-      },
+        keepHeaderOnError: process.env.NODE_ENV !== 'production'
+      }
     },
     'strapi::poweredBy',
     'strapi::logger',
@@ -74,6 +74,6 @@ module.exports = ({ env }) => {
     strapiBody,
     'strapi::session',
     'strapi::favicon',
-    'strapi::public',
-  ];
+    'strapi::public'
+  ]
 }

--- a/src/plugins/ceramic-feed/server/config/defaults.js
+++ b/src/plugins/ceramic-feed/server/config/defaults.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:1337',
+  'http://127.0.0.1:1337',
+  'http://0.0.0.0:1337',
+  'https://localhost:3000',
+  'https://localhost:1337',
+  'https://127.0.0.1:1337',
+  'https://goodwallet.xyz',
+  'https://gooddollar.org',
+  'https://gooddapp.org',
+];
+
+module.exports = {
+  DEFAULT_ALLOWED_ORIGINS,
+};

--- a/src/plugins/ceramic-feed/server/config/index.js
+++ b/src/plugins/ceramic-feed/server/config/index.js
@@ -5,6 +5,15 @@ module.exports = {
     ceramicNodeURL: env('CERAMIC_NODE_URL', 'https://ceramic-clay.3boxlabs.com'),
     web3storageGateway: env('WEB3STORAGE_GATEWAY', 'https://ipfsgateway.goodworker.workers.dev'),
     orbisContext: env('ORBIS_FEED_CONTEXT', 'kjzl6cwe1jw147bfd2hn7f3j2sdsq6708xnb3a217iz1m18a35v25kgxna3s0os'),
+    allowedOrigins: env.array('CERAMIC_FEED_ALLOWED_ORIGINS', [
+      'http://localhost:1337',
+      'http://127.0.0.1:1337',
+      'http://0.0.0.0:1337',
+      'http://localhost:3000',
+      'https://localhost:3000',
+      'https://localhost:1337',
+      'https://127.0.0.1:1337',
+    ]),
   }),
   validator(config) {
     const mandatoryOptions = ['ceramicNodeURL', 'ceramicDIDSeed', 'web3storageGateway']

--- a/src/plugins/ceramic-feed/server/config/index.js
+++ b/src/plugins/ceramic-feed/server/config/index.js
@@ -1,22 +1,30 @@
-'use strict';
+'use strict'
+const { DEFAULT_ALLOWED_ORIGINS } = require('./defaults')
 
 module.exports = {
   default: ({ env }) => ({
-    ceramicNodeURL: env('CERAMIC_NODE_URL', 'https://ceramic-clay.3boxlabs.com'),
-    web3storageGateway: env('WEB3STORAGE_GATEWAY', 'https://ipfsgateway.goodworker.workers.dev'),
-    orbisContext: env('ORBIS_FEED_CONTEXT', 'kjzl6cwe1jw147bfd2hn7f3j2sdsq6708xnb3a217iz1m18a35v25kgxna3s0os'),
+    ceramicNodeURL: env(
+      'CERAMIC_NODE_URL',
+      'https://ceramic-clay.3boxlabs.com'
+    ),
+    web3storageGateway: env(
+      'WEB3STORAGE_GATEWAY',
+      'https://ipfsgateway.goodworker.workers.dev'
+    ),
+    orbisContext: env(
+      'ORBIS_FEED_CONTEXT',
+      'kjzl6cwe1jw147bfd2hn7f3j2sdsq6708xnb3a217iz1m18a35v25kgxna3s0os'
+    ),
     allowedOrigins: env.array('CERAMIC_FEED_ALLOWED_ORIGINS', [
-      'http://localhost:1337',
-      'http://127.0.0.1:1337',
-      'http://0.0.0.0:1337',
-      'http://localhost:3000',
-      'https://localhost:3000',
-      'https://localhost:1337',
-      'https://127.0.0.1:1337',
-    ]),
+      DEFAULT_ALLOWED_ORIGINS
+    ])
   }),
   validator(config) {
-    const mandatoryOptions = ['ceramicNodeURL', 'ceramicDIDSeed', 'web3storageGateway']
+    const mandatoryOptions = [
+      'ceramicNodeURL',
+      'ceramicDIDSeed',
+      'web3storageGateway'
+    ]
 
     mandatoryOptions.forEach(option => {
       if (config[option]) {
@@ -27,5 +35,5 @@ module.exports = {
         `Ceramic connection requires '${option}' option to be set.`
       )
     })
-  },
-};
+  }
+}

--- a/src/plugins/ceramic-feed/server/content-types/ceramic-post/schema.js
+++ b/src/plugins/ceramic-feed/server/content-types/ceramic-post/schema.js
@@ -31,6 +31,11 @@ module.exports = {
       required: true,
       configurable: false
     },
+    context: {
+      type: 'string',
+      required: false,
+      configurable: false
+    },
     picture: {
       type: 'media',
       multiple: false,

--- a/src/plugins/ceramic-feed/server/controllers/index.js
+++ b/src/plugins/ceramic-feed/server/controllers/index.js
@@ -1,3 +1,7 @@
 'use strict';
 
-module.exports = {};
+const posts = require('./posts');
+
+module.exports = {
+  posts,
+};

--- a/src/plugins/ceramic-feed/server/controllers/posts.js
+++ b/src/plugins/ceramic-feed/server/controllers/posts.js
@@ -98,7 +98,7 @@ module.exports = {
 
     ctx.set(
       'Cache-Control',
-      'public, max-age=60, s-maxage=300, stale-while-revalidate=300'
+      'public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600'
     )
     ctx.set('Vary', 'Origin')
     ctx.body = {

--- a/src/plugins/ceramic-feed/server/controllers/posts.js
+++ b/src/plugins/ceramic-feed/server/controllers/posts.js
@@ -1,33 +1,122 @@
-'use strict';
+'use strict'
 
-const { sanitize } = require('@strapi/utils');
-const { contentAPI } = sanitize;
+const { sanitize } = require('@strapi/utils')
+const { contentAPI } = sanitize
 
-const MODEL_UID = 'plugin::ceramic-feed.ceramic-post';
+const MODEL_UID = 'plugin::ceramic-feed.ceramic-post'
+const TAG_FIELD_MAP = {
+  publishwallet: 'publishWallet',
+  publishwalletv2: 'publishWalletV2',
+  publishdapp: 'publishDapp'
+}
+
+const toPositiveInt = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed
+  }
+  return fallback
+}
+
+const buildFilters = ({ tagField, context }) => {
+  const clauses = [{ publishedAt: { $notNull: true } }]
+
+  if (tagField) {
+    clauses.push({ [tagField]: true })
+  }
+
+  if (context) {
+    clauses.push({
+      $or: [{ context }, { context: { $null: true } }, { context: '' }]
+    })
+  }
+
+  if (clauses.length === 1) {
+    return clauses[0]
+  }
+
+  return { $and: clauses }
+}
 
 module.exports = {
   async find(ctx) {
-    const entries = await strapi.entityService.findMany(MODEL_UID, {
-      filters: {
-        publishedAt: { $notNull: true },
-      },
-      sort: { publishedAt: 'desc' },
-      populate: {
-        picture: true,
-        sponsored: true,
-      },
-    });
+    const { query = {} } = ctx.request
+    const rawTag = Array.isArray(query.tag) ? query.tag[0] : query.tag
+    const rawContext = Array.isArray(query.context)
+      ? query.context[0]
+      : query.context
 
-    const schema = strapi.getModel(MODEL_UID);
+    const normalizedTag =
+      typeof rawTag === 'string' ? rawTag.trim().toLowerCase() : null
+    const tagField = normalizedTag ? TAG_FIELD_MAP[normalizedTag] : null
+
+    if (normalizedTag && !tagField) {
+      ctx.throw(400, `Unsupported tag filter '${rawTag}'`)
+    }
+
+    const contextFilter =
+      typeof rawContext === 'string' && rawContext.trim().length
+        ? rawContext.trim()
+        : null
+
+    const page = toPositiveInt(query.page, 1)
+    const pageSize = Math.min(toPositiveInt(query.pageSize, 10), 50)
+    const filters = buildFilters({ tagField, context: contextFilter })
+
+    const offset = (page - 1) * pageSize
+
+    const [entries, total] = await Promise.all([
+      strapi.entityService.findMany(MODEL_UID, {
+        filters,
+        sort: { publishedAt: 'desc' },
+        populate: {
+          picture: true,
+          sponsored: true
+        },
+        start: offset,
+        limit: pageSize
+      }),
+      strapi.db.query(MODEL_UID).count({ where: filters })
+    ])
+
+    const schema = strapi.getModel(MODEL_UID)
     const sanitized = await contentAPI.output(entries, schema, {
-      auth: ctx.state.auth,
-    });
+      auth: ctx.state.auth
+    })
+
+    const pluginConfig = strapi.config.get('plugin.ceramic-feed', {})
+    const defaultContext = pluginConfig.orbisContext || null
+
+    const data = sanitized.map(post => ({
+      ...post,
+      context: post.context ?? defaultContext
+    }))
+
+    const pageCount = Math.ceil(total / pageSize)
+    const nextPage = page < pageCount ? page + 1 : null
+    const prevPage = page > 1 ? page - 1 : null
 
     ctx.set(
       'Cache-Control',
       'public, max-age=60, s-maxage=300, stale-while-revalidate=300'
-    );
-    ctx.set('Vary', 'Origin');
-    ctx.body = sanitized;
-  },
-};
+    )
+    ctx.set('Vary', 'Origin')
+    ctx.body = {
+      data,
+      meta: {
+        pagination: {
+          page,
+          pageSize,
+          pageCount,
+          total,
+          nextPage,
+          prevPage
+        },
+        filters: {
+          context: contextFilter,
+          tag: rawTag ?? null
+        }
+      }
+    }
+  }
+}

--- a/src/plugins/ceramic-feed/server/controllers/posts.js
+++ b/src/plugins/ceramic-feed/server/controllers/posts.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { sanitize } = require('@strapi/utils');
+const { contentAPI } = sanitize;
+
+const MODEL_UID = 'plugin::ceramic-feed.ceramic-post';
+
+module.exports = {
+  async find(ctx) {
+    const entries = await strapi.entityService.findMany(MODEL_UID, {
+      filters: {
+        publishedAt: { $notNull: true },
+      },
+      sort: { publishedAt: 'desc' },
+      populate: {
+        picture: true,
+        sponsored: true,
+      },
+    });
+
+    const schema = strapi.getModel(MODEL_UID);
+    const sanitized = await contentAPI.output(entries, schema, {
+      auth: ctx.state.auth,
+    });
+
+    ctx.set(
+      'Cache-Control',
+      'public, max-age=60, s-maxage=300, stale-while-revalidate=300'
+    );
+    ctx.set('Vary', 'Origin');
+    ctx.body = sanitized;
+  },
+};

--- a/src/plugins/ceramic-feed/server/policies/index.js
+++ b/src/plugins/ceramic-feed/server/policies/index.js
@@ -1,3 +1,7 @@
 'use strict';
 
-module.exports = {};
+const originAllowlist = require('./origin-allowlist');
+
+module.exports = {
+  'origin-allowlist': originAllowlist,
+};

--- a/src/plugins/ceramic-feed/server/policies/origin-allowlist.js
+++ b/src/plugins/ceramic-feed/server/policies/origin-allowlist.js
@@ -1,16 +1,7 @@
 'use strict'
 
 const { PolicyError } = require('@strapi/utils').errors
-
-const DEFAULT_ALLOWLIST = [
-  'http://localhost:3000',
-  'http://localhost:1337',
-  'http://127.0.0.1:1337',
-  'http://0.0.0.0:1337',
-  'https://localhost:3000',
-  'https://localhost:1337',
-  'https://127.0.0.1:1337'
-]
+const { DEFAULT_ALLOWED_ORIGINS } = require('../config/defaults')
 
 const getHeader = (ctx, name) => {
   const headers = ctx.request?.headers
@@ -41,10 +32,13 @@ const getOriginFromHeaders = ctx => {
   }
 }
 
-module.exports = (policyContext, policyConfig, { strapi }) => {
+const allowlistPolicy = (policyContext, policyConfig, { strapi }) => {
   const allowed =
     policyConfig?.origins ??
-    strapi.config.get('plugin.ceramic-feed.allowedOrigins', DEFAULT_ALLOWLIST)
+    strapi.config.get(
+      'plugin.ceramic-feed.allowedOrigins',
+      DEFAULT_ALLOWED_ORIGINS
+    )
 
   const requestOrigin = getOriginFromHeaders(policyContext)
 
@@ -60,3 +54,5 @@ module.exports = (policyContext, policyConfig, { strapi }) => {
     `Origin "${requestOrigin}" not allowed for posts endpoint`
   )
 }
+
+module.exports = allowlistPolicy

--- a/src/plugins/ceramic-feed/server/policies/origin-allowlist.js
+++ b/src/plugins/ceramic-feed/server/policies/origin-allowlist.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const { PolicyError } = require('@strapi/utils').errors;
+const { PolicyError } = require('@strapi/utils').errors
 
 const DEFAULT_ALLOWLIST = [
   'http://localhost:3000',
@@ -9,55 +9,54 @@ const DEFAULT_ALLOWLIST = [
   'http://0.0.0.0:1337',
   'https://localhost:3000',
   'https://localhost:1337',
-  'https://127.0.0.1:1337',
-];
+  'https://127.0.0.1:1337'
+]
 
 const getHeader = (ctx, name) => {
-  const headers = ctx.request?.headers;
+  const headers = ctx.request?.headers
   if (!headers) {
-    return undefined;
+    return undefined
   }
 
-  const lower = name.toLowerCase();
-  return headers[lower];
-};
+  const lower = name.toLowerCase()
+  return headers[lower]
+}
 
 const getOriginFromHeaders = ctx => {
-  const origin = getHeader(ctx, 'origin');
+  const origin = getHeader(ctx, 'origin')
   if (origin) {
-    return origin;
+    return origin
   }
 
-  const referer = getHeader(ctx, 'referer');
+  const referer = getHeader(ctx, 'referer')
   if (!referer) {
-    return null;
+    return null
   }
 
   try {
-    const url = new URL(referer);
-    return url.origin;
+    const url = new URL(referer)
+    return url.origin
   } catch {
-    return null;
+    return null
   }
-};
+}
 
 module.exports = (policyContext, policyConfig, { strapi }) => {
   const allowed =
     policyConfig?.origins ??
-    strapi.config.get(
-      'plugin.ceramic-feed.allowedOrigins',
-      DEFAULT_ALLOWLIST
-    );
+    strapi.config.get('plugin.ceramic-feed.allowedOrigins', DEFAULT_ALLOWLIST)
 
-  const requestOrigin = getOriginFromHeaders(policyContext);
+  const requestOrigin = getOriginFromHeaders(policyContext)
 
   if (!requestOrigin) {
-    return true;
+    return false
   }
 
   if (allowed.includes(requestOrigin)) {
-    return true;
+    return true
   }
 
-  throw new PolicyError('Origin not allowed for posts endpoint');
-};
+  throw new PolicyError(
+    `Origin "${requestOrigin}" not allowed for posts endpoint`
+  )
+}

--- a/src/plugins/ceramic-feed/server/policies/origin-allowlist.js
+++ b/src/plugins/ceramic-feed/server/policies/origin-allowlist.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { PolicyError } = require('@strapi/utils').errors;
+
+const DEFAULT_ALLOWLIST = [
+  'http://localhost:3000',
+  'http://localhost:1337',
+  'http://127.0.0.1:1337',
+  'http://0.0.0.0:1337',
+  'https://localhost:3000',
+  'https://localhost:1337',
+  'https://127.0.0.1:1337',
+];
+
+const getHeader = (ctx, name) => {
+  const headers = ctx.request?.headers;
+  if (!headers) {
+    return undefined;
+  }
+
+  const lower = name.toLowerCase();
+  return headers[lower];
+};
+
+const getOriginFromHeaders = ctx => {
+  const origin = getHeader(ctx, 'origin');
+  if (origin) {
+    return origin;
+  }
+
+  const referer = getHeader(ctx, 'referer');
+  if (!referer) {
+    return null;
+  }
+
+  try {
+    const url = new URL(referer);
+    return url.origin;
+  } catch {
+    return null;
+  }
+};
+
+module.exports = (policyContext, policyConfig, { strapi }) => {
+  const allowed =
+    policyConfig?.origins ??
+    strapi.config.get(
+      'plugin.ceramic-feed.allowedOrigins',
+      DEFAULT_ALLOWLIST
+    );
+
+  const requestOrigin = getOriginFromHeaders(policyContext);
+
+  if (!requestOrigin) {
+    return true;
+  }
+
+  if (allowed.includes(requestOrigin)) {
+    return true;
+  }
+
+  throw new PolicyError('Origin not allowed for posts endpoint');
+};

--- a/src/plugins/ceramic-feed/server/routes/index.js
+++ b/src/plugins/ceramic-feed/server/routes/index.js
@@ -1,1 +1,16 @@
-module.exports = [];
+module.exports = {
+  'content-api': {
+    type: 'content-api',
+    routes: [
+      {
+        method: 'GET',
+        path: '/posts',
+        handler: 'posts.find',
+        config: {
+          auth: false,
+          policies: ['plugin::ceramic-feed.origin-allowlist'],
+        },
+      },
+    ],
+  },
+};

--- a/src/plugins/ceramic-feed/server/store-settings/ceramic-post/settings.js
+++ b/src/plugins/ceramic-feed/server/store-settings/ceramic-post/settings.js
@@ -46,6 +46,20 @@ module.exports = {
         sortable: false
       }
     },
+    context: {
+      edit: {
+        label: 'Orbis context',
+        description: 'Optional context override used by downstream feeds',
+        placeholder: '',
+        visible: true,
+        editable: true
+      },
+      list: {
+        label: 'Orbis context',
+        searchable: true,
+        sortable: true
+      }
+    },
     picture: {
       edit: {
         label: 'Landing picture',


### PR DESCRIPTION
# Description

This introduces that Strapi/GoodCeramic can act as API endpoint for posts.
[x] - Configure allowed domains through env
[x] -  expose endpoint /posts for GET requests

It returns the format that can should be easily consumed by front-ends without much refactor.



About # (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
